### PR TITLE
Add interfaces for token refresh

### DIFF
--- a/auth-client/src/lib/api/authClient.ts
+++ b/auth-client/src/lib/api/authClient.ts
@@ -4,25 +4,32 @@ import { api } from '@react-native-spotify/http-client';
 import { API_CONSTANTS } from '@react-native-spotify/core-constants';
 import { SpotifyTokenResponseDto } from '../model/SpotifyTokenResponseDto.js';
 
-const fetchAccessToken = async (): Promise<SpotifyTokenResponseDto | undefined> => {
-  const { SPOTIFY_CLIENT_ID: CLIENT_ID, SPOTIFY_CLIENT_SECRET: CLIENT_SECRET } = getEnv();
-  const authString = `grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}`;
+export interface AuthClient {
+  fetchAccessToken(): Promise<SpotifyTokenResponseDto | undefined>;
+}
+export class DefaultAuthClient implements AuthClient {
+  async fetchAccessToken(): Promise<SpotifyTokenResponseDto | undefined> {
+    const { SPOTIFY_CLIENT_ID: CLIENT_ID, SPOTIFY_CLIENT_SECRET: CLIENT_SECRET } = getEnv();
+    const authString = `grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}`;
 
-  try {
-    const response = await api.post<SpotifyTokenResponseDto>(
-      `${API_CONSTANTS.ACCOUNTS_API_BASE}token`,
-      authString,
-      {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
+    try {
+      const response = await api.post<SpotifyTokenResponseDto>(
+        `${API_CONSTANTS.ACCOUNTS_API_BASE}token`,
+        authString,
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
         },
-      },
-    );
-    return response.data;
-  } catch (e) {
-    log.error('fetchAccessToken::Une erreur est survenue en chargeant le token Spotify', e);
-    return undefined;
+      );
+      return response.data;
+    } catch (e) {
+      log.error('fetchAccessToken::Une erreur est survenue en chargeant le token Spotify', e);
+      return undefined;
+    }
   }
-};
+}
 
-export { fetchAccessToken };
+export const defaultAuthClient = new DefaultAuthClient();
+
+export const fetchAccessToken = async () => defaultAuthClient.fetchAccessToken();

--- a/auth-client/src/lib/auth-client.spec.ts
+++ b/auth-client/src/lib/auth-client.spec.ts
@@ -1,7 +1,0 @@
-import { authClient } from './auth-client.js';
-
-describe('authClient', () => {
-  it('should work', () => {
-    expect(authClient()).toEqual('auth-client');
-  });
-});

--- a/auth-client/src/lib/auth-client.ts
+++ b/auth-client/src/lib/auth-client.ts
@@ -1,1 +1,2 @@
 export * from '../lib/stores/AuthStore.js';
+export * from '../lib/api/authClient.js';

--- a/auth-client/src/lib/stores/AuthStore.spec.ts
+++ b/auth-client/src/lib/stores/AuthStore.spec.ts
@@ -1,0 +1,33 @@
+import { AuthStore } from './AuthStore.js';
+import { AuthClient } from '../api/authClient.js';
+import { SecureStorage, TokenData } from '@react-native-spotify/keychain-service';
+
+class MockAuthClient implements AuthClient {
+  fetchAccessToken = jest.fn(async () => ({
+    access_token: 'mock-token',
+    token_type: 'Bearer',
+    expires_in: 3600,
+  }));
+}
+
+class MockStorage implements SecureStorage<TokenData> {
+  data?: TokenData;
+  save = jest.fn(async (d: TokenData) => {
+    this.data = d;
+  });
+  get = jest.fn(async () => this.data);
+}
+
+describe('AuthStore with interfaces', () => {
+  it('refreshes and stores token using injected interfaces', async () => {
+    const client = new MockAuthClient();
+    const storage = new MockStorage();
+
+    const store = new AuthStore(client, storage);
+    await store.refreshAccessToken();
+
+    expect(client.fetchAccessToken).toHaveBeenCalled();
+    expect(storage.save).toHaveBeenCalled();
+    expect(store.token).toBe('mock-token');
+  });
+});

--- a/keychain-service/src/lib/keychain-service.ts
+++ b/keychain-service/src/lib/keychain-service.ts
@@ -22,7 +22,12 @@ export interface UserCredentials {
   password: string;
 }
 
-function createSecureStorage<T>(storageKey: string, service: string) {
+export interface SecureStorage<T> {
+  save(data: T): Promise<void>;
+  get(): Promise<T | undefined>;
+}
+
+function createSecureStorage<T>(storageKey: string, service: string): SecureStorage<T> {
   const options = {
     service,
     storage: STORAGE_TYPE.AES_GCM,


### PR DESCRIPTION
## Summary
- define `SecureStorage` interface and use it in `KeyChainService`
- introduce `AuthClient` interface with default implementation
- inject `AuthClient` and `SecureStorage` into `AuthStore`
- export new interface from auth-client package
- add unit test illustrating usage with mocks

## Testing
- `npx nx test auth-client` *(fails: task graph circular dependency)*
- `npx jest --config auth-client/jest.config.ts` *(fails: Jest could not parse TS config)*

------
https://chatgpt.com/codex/tasks/task_e_6855446db3ac8321a3942f139966ccb2